### PR TITLE
Improve pipeline storage with async fs

### DIFF
--- a/app/api/pipelines/[id]/route.ts
+++ b/app/api/pipelines/[id]/route.ts
@@ -3,7 +3,7 @@ import { getPipeline, savePipeline, deletePipeline } from '@/lib/storage';
 
 export async function GET(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params;
-  let pipeline = getPipeline(id);
+  let pipeline = await getPipeline(id);
 
   if (!pipeline) {
     return NextResponse.json({ error: "Pipeline not found" }, { status: 404 });
@@ -16,7 +16,7 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ id:
   const { id } = await context.params;
   const updatedPipeline = await request.json();
 
-  if (savePipeline(id, updatedPipeline)) {
+  if (await savePipeline(id, updatedPipeline)) {
     return NextResponse.json(updatedPipeline);
   }
 
@@ -25,7 +25,7 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ id:
 
 export async function POST(request: NextRequest) {
   const newPipeline = await request.json();
-  if (savePipeline(newPipeline.id, newPipeline)) {
+  if (await savePipeline(newPipeline.id, newPipeline)) {
     return NextResponse.json(newPipeline);
   }
   return NextResponse.json({ error: "Failed to create pipeline" }, { status: 500 });
@@ -33,11 +33,11 @@ export async function POST(request: NextRequest) {
 
 export async function DELETE(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params;
-  const pipeline = getPipeline(id);
+  const pipeline = await getPipeline(id);
   if (!pipeline) {
     return NextResponse.json({ error: "Pipeline not found" }, { status: 404 });
   }
-  if (deletePipeline(id)) {
+  if (await deletePipeline(id)) {
     return NextResponse.json({ success: true });
   }
   return NextResponse.json({ error: "Failed to delete pipeline" }, { status: 500 });

--- a/app/api/pipelines/route.ts
+++ b/app/api/pipelines/route.ts
@@ -3,8 +3,8 @@ import { savePipeline, getPipelines } from '@/lib/storage';
 
 export async function POST(request: NextRequest) {
   const newPipeline = await request.json();
-  
-  if (savePipeline(newPipeline.id, newPipeline)) {
+
+  if (await savePipeline(newPipeline.id, newPipeline)) {
     return NextResponse.json(newPipeline);
   }
   
@@ -13,6 +13,6 @@ export async function POST(request: NextRequest) {
 
 export async function GET() {
   // Read all pipelines from disk and return as array
-  const pipelines = getPipelines();
+  const pipelines = await getPipelines();
   return NextResponse.json(Object.values(pipelines));
-} 
+}

--- a/app/api/run-history/[pipelineId]/route.ts
+++ b/app/api/run-history/[pipelineId]/route.ts
@@ -1,21 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server';
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 const HISTORY_FILE = path.join(process.cwd(), 'data', 'run-history.json');
+fs.mkdir(path.join(process.cwd(), 'data'), { recursive: true }).catch(() => {});
+fs.access(HISTORY_FILE).catch(async () => {
+  await fs.writeFile(HISTORY_FILE, JSON.stringify({}));
+});
 
-function readHistory() {
-  if (!fs.existsSync(HISTORY_FILE)) return {};
-  return JSON.parse(fs.readFileSync(HISTORY_FILE, 'utf-8'));
+async function readHistory() {
+  try {
+    const data = await fs.readFile(HISTORY_FILE, 'utf-8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
 }
 
-function writeHistory(data: any) {
-  fs.writeFileSync(HISTORY_FILE, JSON.stringify(data, null, 2));
+async function writeHistory(data: any) {
+  await fs.writeFile(HISTORY_FILE, JSON.stringify(data, null, 2));
 }
 
 export async function GET(request: NextRequest, { params }: { params: { pipelineId: string } }) {
   const { pipelineId } = params;
-  const history = readHistory();
+  const history = await readHistory();
   const runs = history[pipelineId] || [];
   return NextResponse.json({ runs });
 }
@@ -24,9 +32,9 @@ export async function POST(request: NextRequest, { params }: { params: { pipelin
   const { pipelineId } = params;
   const { run } = await request.json();
   if (!run) return NextResponse.json({ error: 'Missing run' }, { status: 400 });
-  const history = readHistory();
+  const history = await readHistory();
   if (!history[pipelineId]) history[pipelineId] = [];
   history[pipelineId].push(run);
-  writeHistory(history);
+  await writeHistory(history);
   return NextResponse.json({ success: true });
-} 
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,21 +1,20 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 const STORAGE_FILE = path.join(process.cwd(), 'data', 'pipelines.json');
 
 // Ensure the data directory exists
-if (!fs.existsSync(path.join(process.cwd(), 'data'))) {
-  fs.mkdirSync(path.join(process.cwd(), 'data'));
-}
+const dataDir = path.join(process.cwd(), 'data');
+fs.mkdir(dataDir, { recursive: true }).catch(() => {});
 
 // Initialize storage file if it doesn't exist
-if (!fs.existsSync(STORAGE_FILE)) {
-  fs.writeFileSync(STORAGE_FILE, JSON.stringify({}));
-}
+fs.access(STORAGE_FILE).catch(async () => {
+  await fs.writeFile(STORAGE_FILE, JSON.stringify({}));
+});
 
-export function getPipelines() {
+export async function getPipelines() {
   try {
-    const data = fs.readFileSync(STORAGE_FILE, 'utf-8');
+    const data = await fs.readFile(STORAGE_FILE, 'utf-8');
     return JSON.parse(data);
   } catch (error) {
     console.error('Error reading pipelines:', error);
@@ -23,11 +22,11 @@ export function getPipelines() {
   }
 }
 
-export function savePipeline(id: string, pipeline: any) {
+export async function savePipeline(id: string, pipeline: any) {
   try {
-    const pipelines = getPipelines();
+    const pipelines = await getPipelines();
     pipelines[id] = pipeline;
-    fs.writeFileSync(STORAGE_FILE, JSON.stringify(pipelines, null, 2));
+    await fs.writeFile(STORAGE_FILE, JSON.stringify(pipelines, null, 2));
     return true;
   } catch (error) {
     console.error('Error saving pipeline:', error);
@@ -35,19 +34,19 @@ export function savePipeline(id: string, pipeline: any) {
   }
 }
 
-export function getPipeline(id: string) {
-  const pipelines = getPipelines();
+export async function getPipeline(id: string) {
+  const pipelines = await getPipelines();
   return pipelines[id];
 }
 
-export function deletePipeline(id: string) {
+export async function deletePipeline(id: string) {
   try {
-    const pipelines = getPipelines();
+    const pipelines = await getPipelines();
     delete pipelines[id];
-    fs.writeFileSync(STORAGE_FILE, JSON.stringify(pipelines, null, 2));
+    await fs.writeFile(STORAGE_FILE, JSON.stringify(pipelines, null, 2));
     return true;
   } catch (error) {
     console.error('Error deleting pipeline:', error);
     return false;
   }
-} 
+}


### PR DESCRIPTION
## Summary
- refactor storage layer to use async fs operations
- update pipeline and run-history API routes to await async calls

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684127fc656c832081aed0a247601528